### PR TITLE
Support null queries

### DIFF
--- a/src/main/java/com/lifeinide/jsonql/hibernate/search/elastic/HibernateSearchElasticFilterQueryBuilder.java
+++ b/src/main/java/com/lifeinide/jsonql/hibernate/search/elastic/HibernateSearchElasticFilterQueryBuilder.java
@@ -249,7 +249,7 @@ extends BaseHibernateSearchFilterQueryBuilder<E, P, HibernateSearchElasticQueryB
 				context.getEqlBool().withMust(EQLBoolComponent.of(bool));
 		}
 
-		if (!fieldFound)
+		if (!fieldFound && q!=null)
 			throw new SearchException(String.format("No fulltext fields found for: %s", entityClass.getSimpleName()));
 	}
 

--- a/src/test/java/com/lifeinide/jsonql/hibernate/search/elastic/test/HibernateSearchElasticQueryBuilderTest.java
+++ b/src/test/java/com/lifeinide/jsonql/hibernate/search/elastic/test/HibernateSearchElasticQueryBuilderTest.java
@@ -80,11 +80,11 @@ public class HibernateSearchElasticQueryBuilderTest extends JsonQLBaseQueryBuild
 
 		// test for standard list()
 		doWithEntityManager(em -> c.accept(em,
-			new HibernateSearchElasticFilterQueryBuilder<>(em, HibernateSearchElasticEntity.class, SEARCHABLE_STRING)));
+			new HibernateSearchElasticFilterQueryBuilder<>(em, HibernateSearchElasticEntity.class, SEARCHABLE_STRING).withUnlimitedResults()));
 
 		// test for highlight()
 		doWithEntityManager(em -> c.accept(em,
-			new HighlightingHibernateSearchElasticFilterQueryBuilder<HibernateSearchElasticEntity>(em, HibernateSearchElasticEntity.class, SEARCHABLE_STRING)));
+			new HighlightingHibernateSearchElasticFilterQueryBuilder<HibernateSearchElasticEntity>(em, HibernateSearchElasticEntity.class, SEARCHABLE_STRING).withUnlimitedResults()));
 	}
 
 	@Test

--- a/src/test/java/com/lifeinide/jsonql/hibernate/search/elastic/test/HibernateSearchElasticQueryBuilderTest.java
+++ b/src/test/java/com/lifeinide/jsonql/hibernate/search/elastic/test/HibernateSearchElasticQueryBuilderTest.java
@@ -101,6 +101,28 @@ public class HibernateSearchElasticQueryBuilderTest extends JsonQLBaseQueryBuild
 		});
 	}
 
+	@Test
+	public void testNullQuery() {
+		doWithEntityManager(em -> {
+			DefaultHibernateSearchElasticFilterQueryBuilder<?> qb =
+					new DefaultHibernateSearchElasticFilterQueryBuilder<>(em, HibernateSearchElasticEntity.class, null);
+			Page<?> page = qb.list();
+			Assertions.assertEquals(100, page.getCount());
+
+			qb = new DefaultHibernateSearchElasticFilterQueryBuilder<>(em, null);
+			page = qb.add("booleanVal", SingleValueQueryFilter.of(true)).list();
+			Assertions.assertEquals(50, page.getCount());
+
+			qb = new DefaultHibernateSearchElasticFilterQueryBuilder<>(em, null);
+			page = qb.add("stringVal", SingleValueQueryFilter.of("phrase-aa")).list();
+			Assertions.assertEquals(1, page.getCount());
+
+			qb = new DefaultHibernateSearchElasticFilterQueryBuilder<>(em, null);
+			page = qb.list();
+			Assertions.assertEquals(101, page.getCount());
+		});
+	}
+
 	@SuppressWarnings("ConstantConditions")
 	@Test
 	public void testHighlight() {


### PR DESCRIPTION
I'm building a search interface that supports layered navigation.  I want to be able to search for products with and without a query string.  For instance, someone might want to look for all products that are in a certain category, meaning I'm relying only on a `SingleValueFilter` to filter the category.

While admittedly this could be accomplished directly with JPA, I don't want to maintain two separate branches of code conditioned on if the query is present or not.  Additionally, this could give confusing results if the user submits the same search with and without a query term if the behavior between JPA and Elastic is different.

For instance, I want to be able to have something like this:
``` java
@GraphQLQuery(name = "search", description = "Search products")
public GraphQLPage<ProductEntity> search(
    @GraphQLArgument(name="query") String query,
    @GraphQLArgument(name="category") String category,
    @GraphQLArgument(name="page") GraphQLPageable page,
    @GraphQLArgument(name="sort") GraphQLSort sort
) {
    return searchService.searchFilter(ProductEntity.class, query).with(filterCategory(category)).list(page.withSort(sort));
}
```

This change was fairly simple, affecting only one line of code.

I have added test cases for null queries.  Additionally, I had to fix broken test cases in the original checkout to accommodate pre-existing breaking changes in core.
